### PR TITLE
chore: Allow widgets to provide owner metadata

### DIFF
--- a/packages/js-widgets-compiler/registrySchema.json
+++ b/packages/js-widgets-compiler/registrySchema.json
@@ -203,6 +203,22 @@
           },
           "type": "array"
         },
+        "owner": {
+          "properties": {
+            "email": {
+              "format": "email",
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "email",
+            "name"
+          ],
+          "type": "object"
+        },
         "repositoryUrl": {
           "format": "uri",
           "type": "string"


### PR DESCRIPTION
Modifies the `registrySchema.json` file to allow widgets to provide owner information in their metadata file.

Closes #9.