### PR TITLE
fix: install devDependencies when compiling

### DIFF
--- a/packages/js-widgets-compiler/src/moveWidgetDependencies.js
+++ b/packages/js-widgets-compiler/src/moveWidgetDependencies.js
@@ -18,7 +18,7 @@ module.exports = async (widget, origin, destination) => {
   const { shortcode } = widget;
   const packageManagerName = 'npm';
   debug(`[info] - [${shortcode}] Installing dependencies.`);
-  await runCommand(packageManagerName, ['install'], {
+  await runCommand(packageManagerName, ['install', '--production=false'], {
     cwd: origin,
     scope: shortcode,
     successMessage: 'Dependencies were successfully installed.',


### PR DESCRIPTION
These may be necessary for a successful "npm run build" and may
not be present when NODE_ENV is "production" when running the
compiler.