### PR TITLE
Add command to check for .nvmrc file and switch to appropriate Node version.

### DIFF
--- a/packages/js-widgets-compiler/src/moveWidgetDependencies.js
+++ b/packages/js-widgets-compiler/src/moveWidgetDependencies.js
@@ -20,12 +20,15 @@ module.exports = async (widget, origin, destination) => {
   debug(
     `[info] - [${shortcode}] Installing dependencies including devDependencies.`,
   );
-  await runCommand('nvm use', [], {
-    cwd: origin,
-    scope: shortcode,
-    successMessage:
-      "Checking for .nvmrc file. Switching to widget's configured Node version if found.",
-  });
+  try {
+    await runCommand('nvm use', [], {
+      cwd: origin,
+      scope: shortcode,
+      successMessage: `.nvmrc file found. Switching to Node ${process.version}.`,
+    });
+  } catch (error) {
+    debug(`[info] - No .nvmrc file found. Using Node ${process.version}.`);
+  }
   await runCommand(packageManagerName, ['install', '--also', 'dev'], {
     cwd: origin,
     scope: shortcode,

--- a/packages/js-widgets-compiler/src/moveWidgetDependencies.js
+++ b/packages/js-widgets-compiler/src/moveWidgetDependencies.js
@@ -20,6 +20,12 @@ module.exports = async (widget, origin, destination) => {
   debug(
     `[info] - [${shortcode}] Installing dependencies including devDependencies.`,
   );
+  await runCommand('nvm use', [], {
+    cwd: origin,
+    scope: shortcode,
+    successMessage:
+      "Checking for .nvmrc file. Switching to widget's configured Node version if found.",
+  });
   await runCommand(packageManagerName, ['install', '--also', 'dev'], {
     cwd: origin,
     scope: shortcode,

--- a/packages/js-widgets-compiler/src/moveWidgetDependencies.test.js
+++ b/packages/js-widgets-compiler/src/moveWidgetDependencies.test.js
@@ -18,6 +18,6 @@ describe('moveWidgetDependencies', () => {
       'tests/destination',
       false,
     );
-    expect(runCommand).toHaveBeenCalledTimes(2);
+    expect(runCommand).toHaveBeenCalledTimes(3);
   });
 });


### PR DESCRIPTION
Each widget has its own version of Node set with an .nvmrc file. Though the boilerplate, from which all widgets originate, defines the Node version, the registry uses its own set version of Node when compiling. This diff adds a command before the install that checks for an .nvmrc file and, if found, switches to the appropriate Node version.